### PR TITLE
Refactor/pokemon details

### DIFF
--- a/src/Components/Card/Card.tsx
+++ b/src/Components/Card/Card.tsx
@@ -11,7 +11,7 @@ type PokeCardProps = {
   name?: string;
   sprites?: {
     other: {
-      dream_world: {
+      'official-artwork': {
         front_default: string
       }
     }
@@ -33,7 +33,7 @@ const Card: React.FC<CardProps> = ({ name }: CardProps) => {
     <button className="card"> 
       <Link to={`/${pokeCard.name}`} style={{ textDecoration: "none" }}>
       <img
-        src={pokeCard.sprites?.other?.dream_world?.front_default}
+      src={pokeCard.sprites?.other['official-artwork'].front_default} 
         alt={pokeCard.name}
         className="cardImage"
       />

--- a/src/Components/PokemonDetails/PokemonDetails.tsx
+++ b/src/Components/PokemonDetails/PokemonDetails.tsx
@@ -38,7 +38,7 @@ const PokemonDetails: React.FC<PokemonDetailsProps> = ({ pokemonName }) => {
                         <p className="pokemon-id">#{pokemon.id}</p>
                     </div>
                     <div className='image-container'>
-                        <img className='pokemon-image' src={pokemon.sprites?.other?.dream_world?.front_default} alt={pokemon.name} />
+                        <img className='pokemon-image' src={pokemon.sprites && pokemon.sprites.other && pokemon.sprites.other['official-artwork'] && pokemon.sprites.other['official-artwork'].front_default} alt={pokemon.name} />
                     </div>
                     <div className='height-and-weight'>
                         <p className="pokemon-height">Height: {pokemon.height / 10}m</p>


### PR DESCRIPTION
## What does this merge do? Check all that apply.
- [ ] Adds a new feature
- [ ] Improves an existing feature
- [x] Fixes a bug
- [x] Cleans up (logs, tests, etc.)

## How has this been tested?
- Running the server on localhost:3000 
- Searching for a Pokemon that does not have a dream_world sprite (pokemon at the end of the list). 

## Description
- More than half of the Pokemon do not have spites (pictures) for dream_world. For these Pokemon, if you checked the API, `pokemon.spites.other.dream_world.front_default` returns `null`
- Since all pokemon have `pokemon.sprites.other.official-artwork` I refactored the img HTML tag within the PokemonDetails.tsx file so that it uses that picture for all the pokemon instead 
- Also made changes within the Card.tsx file so that they are consistent with the images used in the changes above. 

## Issues
- None! Let me know if you have questions!

## Where to find Changes
Files: PokemonDetails.tsx, Card.tsx

## Checklist
- [x] My code follows the style guidelines of this project
- [ ] We have performed a group-review of the code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have used tests to prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my change